### PR TITLE
Small update of stan_inference.jl to include Stan's exposed Adams solver

### DIFF
--- a/src/stan_inference.jl
+++ b/src/stan_inference.jl
@@ -47,7 +47,7 @@ function generate_theta(n,priors)
 end
 
 function stan_inference(prob::DiffEqBase.DEProblem,t,data,priors = nothing,
-                            stanmodel = nothing;alg=:rk45,
+                            stanmodel = nothing;alg=:adams,
                             num_samples=1000, num_warmup=1000, reltol=1e-3,
                             abstol=1e-6, maxiter=Int(1e5),likelihood=Normal,
                             vars=(StanODEData(),InverseGamma(3,3)),nchains=1,
@@ -65,12 +65,14 @@ function stan_inference(prob::DiffEqBase.DEProblem,t,data,priors = nothing,
   end
   
   if stanmodel === nothing
-    if alg ==:rk45
+    if alg ==:adams
+      algorithm = "integrate_ode_adams"
+    elseif alg ==:rk45
       algorithm = "integrate_ode_rk45"
     elseif alg == :bdf
       algorithm = "integrate_ode_bdf"
     else
-      error("The choices for alg are :rk45 or :bdf")
+      error("The choices for alg are :adams, :rk45, or :bdf")
     end
     hyper_params = ""
     tuple_hyper_params = ""

--- a/src/stan_inference.jl
+++ b/src/stan_inference.jl
@@ -47,7 +47,7 @@ function generate_theta(n,priors)
 end
 
 function stan_inference(prob::DiffEqBase.DEProblem,t,data,priors = nothing,
-                            stanmodel = nothing;alg=:adams,
+                            stanmodel = nothing;alg=:rk45,
                             num_samples=1000, num_warmup=1000, reltol=1e-3,
                             abstol=1e-6, maxiter=Int(1e5),likelihood=Normal,
                             vars=(StanODEData(),InverseGamma(3,3)),nchains=1,


### PR DESCRIPTION
Stan has had an Adams-Moulton method exposed for the past couple of years now as `integrate_ode_adams`, but I only recently found out because it was only explicitly mentioned in the latest update of their documentation. Refer to https://github.com/stan-dev/stan/issues/2542. Now recommended as the default non-stiff solver by people in the Stan community over rk45. Just a small suggested update to accommodate that as a result. Thanks to the DifferentialEquations.jl team for their hard work once more!