### PR TITLE
add delta key word

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         group:
           - Core

--- a/src/stan_inference.jl
+++ b/src/stan_inference.jl
@@ -62,6 +62,7 @@ function stan_inference(prob::DiffEqBase.DEProblem,
                         # stan_sample keyword arguments
                         num_samples = 1000, num_warmups = 1000,
                         num_cpp_chains = 1, num_chains = 1, num_threads = 1,
+                        delta=0.8,
                         # read_samples arguments
                         output_format = :mcmcchains,
                         # read_summary arguments
@@ -200,7 +201,7 @@ function stan_inference(prob::DiffEqBase.DEProblem,
                 "t0" => prob.tspan[1], "ts" => t)
 
     @time rc = stan_sample(stanmodel; data, num_threads, num_cpp_chains,
-                           num_samples, num_warmups, num_chains)
+                           num_samples, num_warmups, num_chains,delta)
 
     if success(rc)
         return StanResult(stanmodel, rc, read_samples(stanmodel, output_format))

--- a/src/stan_inference.jl
+++ b/src/stan_inference.jl
@@ -201,7 +201,7 @@ function stan_inference(prob::DiffEqBase.DEProblem,
                 "t0" => prob.tspan[1], "ts" => t)
 
     @time rc = stan_sample(stanmodel; data, num_threads, num_cpp_chains,
-                           num_samples, num_warmups, num_chains,delta)
+                           num_samples, num_warmups, num_chains, delta)
 
     if success(rc)
         return StanResult(stanmodel, rc, read_samples(stanmodel, output_format))

--- a/src/stan_inference.jl
+++ b/src/stan_inference.jl
@@ -62,7 +62,7 @@ function stan_inference(prob::DiffEqBase.DEProblem,
                         # stan_sample keyword arguments
                         num_samples = 1000, num_warmups = 1000,
                         num_cpp_chains = 1, num_chains = 1, num_threads = 1,
-                        delta=0.8,
+                        delta = 0.8,
                         # read_samples arguments
                         output_format = :mcmcchains,
                         # read_summary arguments


### PR DESCRIPTION
To allow user to  modify, adapt_delta parameter, e.g. in Turing this is often set lower for ODE models.