### PR TITLE
Fix documentation build by adding Turing dependency

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -13,6 +13,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TransformVariables = "84d833dd-6860-57f9-a1a7-6da5db126cff"
+Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"
 
 [compat]
 BenchmarkTools = "1"
@@ -28,3 +29,4 @@ StanSample = "7"
 StatsBase = "0.33, 0.34"
 StatsPlots = "0.15"
 TransformVariables = "0.8"
+Turing = "0.38, 0.39"


### PR DESCRIPTION
## Summary
Fixes the documentation build failure by adding the missing Turing dependency.

## Problem
The documentation examples use `turing_inference` but Turing was not listed as a dependency in `docs/Project.toml`, causing the docs build to fail.

## Solution
This PR adds:
- Turing to the `[deps]` section of `docs/Project.toml`
- `Turing = "0.38, 0.39"` to the `[compat]` section

## Test plan
- [ ] Documentation builds successfully
- [ ] All `turing_inference` examples in the docs run without errors

This fix ensures that the documentation can be built with all the necessary dependencies for the code examples.

🤖 Generated with [Claude Code](https://claude.ai/code)